### PR TITLE
ci: guard container publishing on forks

### DIFF
--- a/.github/workflows/main-docker.yml
+++ b/.github/workflows/main-docker.yml
@@ -109,6 +109,9 @@ jobs:
 
   build:
     name: Build Docker images
+    # Forks can still run test_docker, but only the canonical repository may
+    # publish per-platform images and attestations.
+    if: ${{ github.repository == 'TriliumNext/Trilium' }}
     strategy:
       fail-fast: false
       matrix:
@@ -216,6 +219,7 @@ jobs:
 
   merge:
     name: Merge manifest lists
+    if: ${{ github.repository == 'TriliumNext/Trilium' }}
     runs-on: ubuntu-latest
     needs:
       - build


### PR DESCRIPTION
## Summary

Keep the Docker build test available in forks while restricting image publication to `TriliumNext/Trilium`. Recent fork runs reached the Docker Hub login and failed because upstream maintainer credentials are intentionally unavailable.

Both jobs that write images or manifests are guarded. The load-only `test_docker` job remains unchanged.

## Verification

Validated YAML parsing, GitHub Actions syntax, and whitespace.

_codex-gpt-5.6-sol-medium on behalf of matt wilkie_
